### PR TITLE
docs: update links to "Béla Bartók's Axis System" and "Tonnetz for Seventh Chords"

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Transformations between triad chords and different types of seventh chords. The 
 
 - [x]  `p1M, l1d, p2m, r2M, p3d, r3m, p4M, l4m, p5d, r5d, rr5d, z5d`
 
-Mathematical inspiration in the paper:
+Mathematical inspiration in [**the paper**](https://hal.science/hal-02021946/):
 
 ```text
 A Generalized Dual of the Tonnetz for Seventh Chords:

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Mathematical, Computational and Compositional Aspects
 ```
 ### Extensions of the Axis System in Béla Bartók
 
-Generalized implementation on any Tonnetz of the harmonic groups of **axis system** ideaded by [**Ernő Lendvai**](http://www.harmonicwheel.com/bartok_axes.pdf): Tonic (8 chords), Subdominant (8 chords), and Dominant (8 chords). The parameters specify two directions, sought emotion (based on the ideas of [**Mauro de Maria**](https://www.youtube.com/watch?v=EhmbTaEKUZo)), cross or diagonal movement. Major-minor and minor-major alternation available for cross path.
+Generalized implementation on any Tonnetz of the harmonic groups of **axis system** ideaded by [**Ernő Lendvai**](https://web.archive.org/web/20150614031849/http://www.harmonicwheel.com/bartok_axes.pdf): Tonic (8 chords), Subdominant (8 chords), and Dominant (8 chords). The parameters specify two directions, sought emotion (based on the ideas of [**Mauro de Maria**](https://www.youtube.com/watch?v=EhmbTaEKUZo)), cross or diagonal movement. Major-minor and minor-major alternation available for cross path.
 
 The manipulation can be done using a single function:
 * `genCardinalPoints()`


### PR DESCRIPTION
Hello, thank you for this wonderful open-source library. I just started learning about it, and noticed there was a broken link in the README to the document on Bartók's Axis System.

Original URL: http://www.harmonicwheel.com/bartok_axes.pdf

Looks like the domain `harmonicwheel.com` has expired. Too bad, it was a fascinating website in English and Spanish (`ruedaarmonica.com`) about the Harmonic Wheel by Luis Nuño, based on the Tonnetz as 2D polar grid. Fortunately there's a [historical snapshot of the site](https://web.archive.org/web/20150614031849/http://www.harmonicwheel.com) at `archive.org` and the document is accessible there.

Archived URL: https://web.archive.org/web/20150614031849/http://www.harmonicwheel.com/bartok_axes.pdf

This pull request updates the link to the archived PDF document.

---

It also adds a link to the paper by Sonia Cannas on "Tonnetz for Seventh Chords". The document is at: https://hal.science/hal-02021946/

---

More recently, professor Luis Nuño published a technical article, ["Representation of harmonies on the harmonic wheel"](https://www.tenor-conference.org/proceedings/2020/03_Nuno_tenor20.pdf) (PDF), presented at the Sixth International Conference on Technologies for Music Notation and Representation (TENOR 2020).

If you hadn't seen it I thought you'd enjoy it as a unique take on the Tonnetz. The paper is what indirectly led me to this `ts-tonnetz` library.

---

Another link I wanted to mention:

- [Ziffers - Numbered Musical Notation for Live Coding and Algorithmic Composition](https://zenodo.org/records/7841945) (April 2023)

I found this article by chance during my explorations, and I realized the authors are the ones who developed ZiffersJS (whose [repository](https://github.com/amiika/zifferjs) doesn't have much technical information as the [original Ruby library](https://github.com/amiika/ziffers) and [wiki](https://github.com/amiika/ziffers/wiki)).